### PR TITLE
Download binaries for all platforms and architectures

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,6 +1,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const os = require("node:os");
+const { execSync } = require("node:child_process");
 const https = require("https");
 const yauzl = require("yauzl");
 const Downloader = require("nodejs-file-downloader");
@@ -8,99 +9,159 @@ const Downloader = require("nodejs-file-downloader");
 const ZIP_BASE = "https://github.com/alphacep/vosk-api/releases/download";
 
 const ZIP = {
-    win32: {
-        x64: "/v0.3.42/vosk-win64-0.3.42.zip",
-        ia32: "/v0.3.42/vosk-win32-0.3.42.zip",
-    },
-    darwin: {
-        arm64: "/v0.3.42/vosk-osx-0.3.42.zip",
-        x64: "/v0.3.42/vosk-osx-0.3.42.zip",
-    },
-    linux: {
-        arm64: "/v0.3.43/vosk-linux-aarch64-0.3.43.zip",
-        arm: "/v0.3.43/vosk-linux-armv7l-0.3.43.zip",
-        x64: "/v0.3.43/vosk-linux-x86_64-0.3.43.zip",
-        ia32: "/v0.3.43/vosk-linux-x86-0.3.43.zip",
-    },
+  win32: {
+    x64: "/v0.3.42/vosk-win64-0.3.42.zip",
+    ia32: "/v0.3.42/vosk-win32-0.3.42.zip",
+  },
+  darwin: {
+    arm64: "/v0.3.42/vosk-osx-0.3.42.zip",
+    x64: "/v0.3.42/vosk-osx-0.3.42.zip",
+  },
+  linux: {
+    arm64: "/v0.3.43/vosk-linux-aarch64-0.3.43.zip",
+    arm: "/v0.3.43/vosk-linux-armv7l-0.3.43.zip",
+    x64: "/v0.3.43/vosk-linux-x86_64-0.3.43.zip",
+    ia32: "/v0.3.43/vosk-linux-x86-0.3.43.zip",
+  },
 };
 
 const VERBOSE = true;
-const LIB_DIR = path.resolve(__dirname, "..", `bin-${process.platform}-${process.arch}`);
+const LIB_DIR = path.resolve(
+  __dirname,
+  "..",
+  `bin-${process.platform}-${process.arch}`,
+);
 
 (async () => {
-    if (!fs.existsSync(LIB_DIR)) {
-        fs.mkdirSync(LIB_DIR, { recursive: true });
-    }
+  const ignorePlatform = detectInstallIgnorePlatform();
 
-    if (fs.existsSync(path.resolve(LIB_DIR, "DONE"))) {
-        VERBOSE && console.log("Library already downloaded.");
-        return;
-    }
+  const remotes = ignorePlatform
+    ? Object.entries(ZIP).flatMap(([platform, arches]) =>
+        Object.entries(arches).map(([arch, remote]) => [
+          remote,
+          path.resolve(__dirname, "..", `bin-${platform}-${arch}`),
+        ]),
+      )
+    : [[ZIP[process.platform]?.[process.arch], LIB_DIR]];
 
-    const remote = ZIP[process.platform]?.[process.arch];
+  if (!ignorePlatform && remotes[0] === undefined) {
+    throw new Error(
+      `Unsupported platform: ${process.platform}-${process.arch}`,
+    );
+  }
 
-    if (remote === undefined) {
-        throw new Error(`Unsupported platform: ${process.platform}-${process.arch}`);
-    }
+  Promise.allSettled(
+    remotes.map(([remote, libDir]) => {
+      return (async () => {
+        if (!fs.existsSync(libDir)) {
+          fs.mkdirSync(libDir, { recursive: true });
+        }
 
-    // await download(ZIP_BASE + remote, zip);
-    const downloader = new Downloader({
-        url: ZIP_BASE + remote,
-        directory: LIB_DIR
+        if (fs.existsSync(path.resolve(libDir, "DONE"))) {
+          VERBOSE && console.log("Library already downloaded.");
+          return;
+        }
+        await download(ZIP_BASE + remote, libDir);
+        await unzip(path.resolve(libDir, path.basename(remote)), libDir);
+        fs.unlinkSync(path.resolve(libDir, path.basename(remote)));
+      })();
+    }),
+  ).then((results) => {
+    results.forEach((result) => {
+      if (result.status === "rejected") {
+        console.error(result.reason);
+      }
     });
-    const { filePath } = await downloader.download();
-    VERBOSE && console.log("Downloaded file to", filePath);
-
-    await unzip(filePath, LIB_DIR);
-    fs.unlinkSync(filePath);
+  });
 })();
 
-
+async function download(url, dest) {
+  const downloader = new Downloader({
+    url,
+    directory: dest,
+  });
+  const { filePath } = await downloader.download();
+  VERBOSE && console.log("Downloaded file to", filePath);
+}
 
 function unzip(zip, dest) {
-    const dir = path.basename(zip, ".zip");
-    return new Promise((resolve, reject) => {
-        yauzl.open(zip, { lazyEntries: true }, (err, zipfile) => {
-            if (err) {
-                reject(err);
-            }
+  const dir = path.basename(zip, ".zip");
+  return new Promise((resolve, reject) => {
+    yauzl.open(zip, { lazyEntries: true }, (err, zipfile) => {
+      if (err) {
+        reject(err);
+      }
+      zipfile.readEntry();
+      zipfile
+        .on("entry", (entry) => {
+          if (/\/$/.test(entry.fileName)) {
             zipfile.readEntry();
-            zipfile
-                .on("entry", (entry) => {
-                    if (/\/$/.test(entry.fileName)) {
-                        zipfile.readEntry();
-                    } else {
-                        zipfile.openReadStream(entry, (err, stream) => {
-                            if (err) {
-                                reject(err);
-                            }
-                            const f = path.resolve(dest, entry.fileName.replace(`${dir}/`, ""));
-                            if (!fs.existsSync(path.dirname(f))) {
-                                fs.mkdirSync(path.dirname(f), { recursive: true });
-                                VERBOSE && console.log("Created directory", path.dirname(f));
-                            }
-                            stream.pipe(fs.createWriteStream(f));
-                            stream
-                                .on("end", () => {
-                                    VERBOSE && console.log("Extracted", f);
-                                    zipfile.readEntry();
-                                })
-                                .on("error", (err) => {
-                                    reject(err);
-                                });
-                        });
-                    }
+          } else {
+            zipfile.openReadStream(entry, (err, stream) => {
+              if (err) {
+                reject(err);
+              }
+              const f = path.resolve(
+                dest,
+                entry.fileName.replace(`${dir}/`, ""),
+              );
+              if (!fs.existsSync(path.dirname(f))) {
+                fs.mkdirSync(path.dirname(f), { recursive: true });
+                VERBOSE && console.log("Created directory", path.dirname(f));
+              }
+              stream.pipe(fs.createWriteStream(f));
+              stream
+                .on("end", () => {
+                  VERBOSE && console.log("Extracted", f);
+                  zipfile.readEntry();
                 })
                 .on("error", (err) => {
-                    reject(err);
-                })
-                .on("end", () => {
-                    VERBOSE && console.log("Extracted all files");
-                    fs.writeFileSync(path.resolve(dest, "DONE"), "");
-                })
-                .on("close", () => {
-                    resolve();
+                  reject(err);
                 });
+            });
+          }
+        })
+        .on("error", (err) => {
+          reject(err);
+        })
+        .on("end", () => {
+          VERBOSE && console.log("Extracted all files");
+          fs.writeFileSync(path.resolve(dest, "DONE"), "");
+        })
+        .on("close", () => {
+          resolve();
         });
     });
+  });
+}
+
+function detectInstallIgnorePlatform() {
+  try {
+    // Get the parent process ID (PPID) of the current process
+    const ppid = process.ppid;
+
+    // Use a platform-specific command to get the command line of the parent process
+    let command;
+    if (process.platform === "win32") {
+      command = `wmic process where (ProcessId=${ppid}) get CommandLine`;
+    } else {
+      command = `ps -o args= -p ${ppid}`;
+    }
+
+    // Execute the command to get the command line of the parent process
+    const result = execSync(command, { encoding: "utf8" });
+
+    // Check if the command line contains '--ignore-platform'
+    if (result.includes("--ignore-platform")) {
+      VERBOSE && console.log("Install command was run with --ignore-platform");
+      return true;
+    } else {
+      VERBOSE &&
+        console.log("Install command was not run with --ignore-platform");
+      return false;
+    }
+  } catch (error) {
+    console.error("Error detecting --ignore-platform:", error);
+    return false;
+  }
 }


### PR DESCRIPTION
Hi there! First of all, thank you for this implementation.
  
I am planning to use it in an app built with Electron, so during the build process, all the Vosk binaries are needed, as the builds are made for different OSs. Currently, to handle this, we use the yarn flag --ignore-platform, which downloads all available binaries for libraries that have this type of differentiation.
  
I have modified the postinstall script to detect if this flag is used and to download all binaries accordingly. If the flag is not detected, the behavior remains the same as before, with only the binaries for the current platform and architecture being downloaded.
  
I believe these changes will make the build process more versatile and convenient, especially for projects that need to support multiple platforms. Please review the modifications, and let me know if there are any adjustments or improvements you would suggest. I am happy to make any necessary changes.

Thank you for considering this contribution!