### PR TITLE
yauzl has been moved to the main dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
   },
   "dependencies": {
     "koffi": "^2.8.6",
-    "nodejs-file-downloader": "^4.12.1"
+    "nodejs-file-downloader": "^4.12.1",
+    "yauzl": "^3.1.2"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",
     "tsup": "^5.12.9",
-    "typescript": "^4.7.4",
-    "yauzl": "^3.1.2"
+    "typescript": "^4.7.4"
   }
 }


### PR DESCRIPTION
Without yauzl in the dependencies, the work will be incorrect. Otherwise, you will have to install it in your project.